### PR TITLE
Bump `syn` and `darling`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-syn = "1.0"
+syn = "2.0"
 quote = "1.0"
-darling = "0.10"
+darling = "0.20"
 proc-macro2 = "1.0"
 
 [lib]


### PR DESCRIPTION
The crate is using very old versions of both crates. This was causing duplicate dependency in on our end because of other crates pulling in more recent versions.

After bumping them, I've encountered no compilation errors, and we haven't run into any issues with our use case of nvml-wrapper.